### PR TITLE
Add category reordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,19 +150,31 @@ if(!currentUser){
 
 <!-- ✅ Category Sections for Tasks -->
 <div class="section" id="maintenance">
-  <h3>🛠 Maintenance & Management</h3>
+  <h3>🛠 Maintenance &amp; Management
+    <button onclick="moveCategory('maintenance',-1)">⬆️</button>
+    <button onclick="moveCategory('maintenance',1)">⬇️</button>
+  </h3>
 </div>
 
 <div class="section" id="strategy">
-  <h3>📦 Strategic Additions</h3>
+  <h3>📦 Strategic Additions
+    <button onclick="moveCategory('strategy',-1)">⬆️</button>
+    <button onclick="moveCategory('strategy',1)">⬇️</button>
+  </h3>
 </div>
 
 <div class="section" id="savings">
-  <h3>💾 Operational Savings</h3>
+  <h3>💾 Operational Savings
+    <button onclick="moveCategory('savings',-1)">⬆️</button>
+    <button onclick="moveCategory('savings',1)">⬇️</button>
+  </h3>
 </div>
 
 <div class="section" id="protection">
-  <h3>🛡 Brand Protection</h3>
+  <h3>🛡 Brand Protection
+    <button onclick="moveCategory('protection',-1)">⬆️</button>
+    <button onclick="moveCategory('protection',1)">⬇️</button>
+  </h3>
 </div>
 
 <!-- ✅ Notes Section -->
@@ -264,6 +276,13 @@ function addCategory() {
   // Create section
   createCategorySection(id, newName);
 
+  // Update order
+  const orderKey = `billionaireCategoryOrder_${currentUser}`;
+  const order = JSON.parse(localStorage.getItem(orderKey) || "[]");
+  order.push(id);
+  localStorage.setItem(orderKey, JSON.stringify(order));
+  reorderCategorySections(order);
+
 
   input.value = "";
 }
@@ -282,6 +301,11 @@ function removeCategory(){
   let saved = JSON.parse(localStorage.getItem(`billionaireCategories_${currentUser}`) || "[]");
   saved = saved.filter(c => c.id !== id);
   localStorage.setItem(`billionaireCategories_${currentUser}`, JSON.stringify(saved));
+  const orderKey = `billionaireCategoryOrder_${currentUser}`;
+  let order = JSON.parse(localStorage.getItem(orderKey) || "[]");
+  order = order.filter(cid => cid !== id);
+  localStorage.setItem(orderKey, JSON.stringify(order));
+  reorderCategorySections(order);
   saveTasks();
 }
 
@@ -396,7 +420,7 @@ function createCategorySection(id, name) {
   const section = document.createElement("div");
   section.className = "section";
   section.id = id;
-  section.innerHTML = `<h3>${name}</h3>`;
+  section.innerHTML = `<h3>${name} <button onclick="moveCategory('${id}',-1)">⬆️</button> <button onclick="moveCategory('${id}',1)">⬇️</button></h3>`;
   document.body.insertBefore(section, document.getElementById("notesList").parentElement);
 }
 
@@ -406,6 +430,43 @@ function loadCategories(){
     addCategoryToDropdowns(id, name);
     createCategorySection(id, name);
   });
+  const orderKey = `billionaireCategoryOrder_${currentUser}`;
+  const defaultOrder = ["maintenance","strategy","savings","protection"].concat(saved.map(c => c.id));
+  let order = JSON.parse(localStorage.getItem(orderKey) || "[]");
+  if(order.length === 0){
+    order = defaultOrder;
+    localStorage.setItem(orderKey, JSON.stringify(order));
+  } else {
+    defaultOrder.forEach(id => { if(!order.includes(id)) order.push(id); });
+    order = order.filter(id => defaultOrder.includes(id));
+    localStorage.setItem(orderKey, JSON.stringify(order));
+  }
+  reorderCategorySections(order);
+</script>
+
+<script>
+function reorderCategorySections(order){
+  const notesSection = document.getElementById("notesList").parentElement;
+  order.forEach(id => {
+    const section = document.getElementById(id);
+    if(section){
+      document.body.insertBefore(section, notesSection);
+    }
+  });
+}
+
+function moveCategory(id, direction){
+  const orderKey = `billionaireCategoryOrder_${currentUser}`;
+  let order = JSON.parse(localStorage.getItem(orderKey) || "[]");
+  const index = order.indexOf(id);
+  if(index === -1) return;
+  const newIndex = index + direction;
+  if(newIndex < 0 || newIndex >= order.length) return;
+  const temp = order[index];
+  order[index] = order[newIndex];
+  order[newIndex] = temp;
+  localStorage.setItem(orderKey, JSON.stringify(order));
+  reorderCategorySections(order);
 }
 </script>
 


### PR DESCRIPTION
## Summary
- allow moving categories up or down
- persist custom order in browser storage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e1e9ef03483298123f53ccb48e816